### PR TITLE
Destroy method incomplete. Fixed.

### DIFF
--- a/jquery.twbsPagination.js
+++ b/jquery.twbsPagination.js
@@ -68,6 +68,7 @@
         destroy: function () {
             this.$element.empty();
             this.$element.removeData('twbs-pagination');
+            this.$element.unbind('page');
             return this;
         },
 


### PR DESCRIPTION
I was trying to recreate the paginator but it wouldn't work even after calling "destroy", it was only removing children. I found that the plugin was checking for the presence of data "twbs-pagination" before calling the constructor. This fix the issue by removing data and also unbinding all event listeners. 
